### PR TITLE
fix: make deploy scripts idempotent and prevent PORT env leak

### DIFF
--- a/deploy-backend-prod.sh
+++ b/deploy-backend-prod.sh
@@ -11,13 +11,16 @@ nvm use 22
 
 cd "$BACKEND_PROD_PATH"
 
-echo "Pulling latest changes..."
-git pull origin main
+echo "Resetting to latest main..."
+git fetch origin main
+git checkout main --force
+git reset --hard origin/main
 
 echo "Installing dependencies..."
 npm install
 
 echo "Restarting server..."
+unset PORT
 pm2 restart "$BACKEND_PROD_PM2_NAME" --update-env
 
 echo "Backend production deployment complete"

--- a/deploy-frontend-prod.sh
+++ b/deploy-frontend-prod.sh
@@ -11,8 +11,10 @@ nvm use 22
 
 cd "$FRONTEND_PROD_PATH"
 
-echo "Pulling latest changes..."
-git pull origin main
+echo "Resetting to latest main..."
+git fetch origin main
+git checkout main --force
+git reset --hard origin/main
 
 echo "Installing dependencies..."
 npm install


### PR DESCRIPTION
## Summary
- Deploy scripts now use `git fetch + checkout + reset --hard` instead of `git pull`, preventing failures from dirty local state or divergent branches
- `unset PORT` before `pm2 restart --update-env` stops CICD's `PORT=3001` from overriding the backend's `PORT=3000`

## Test plan
- [x] Backend deploy verified working after fix
- [x] Frontend deploy script updated with same idempotent git pattern